### PR TITLE
Mitigate User Right Issues On RDS

### DIFF
--- a/src/Protector.php
+++ b/src/Protector.php
@@ -339,6 +339,7 @@ class Protector
         $dumpOptions->push(sprintf('-p%s', escapeshellarg($this->connectionConfig['password'])));
         $dumpOptions->push(sprintf('--max-allowed-packet=%s', escapeshellarg(config('protector.maxPacketLength'))));
         $dumpOptions->push('--no-create-db');
+        $dumpOptions->push('--set-gtid-purged=off');
 
         if ($options['no-data'] ?? false) {
             $dumpOptions->push('--no-data');


### PR DESCRIPTION
This PR re-adds the previously used --set-gtid-purged=off parameter to prevent mysqldump from setting SESSION.SQL_LOG_BIN=0 which requires SUPER privileges during import on RDS.