### PR TITLE
bugfix / telescope collision

### DIFF
--- a/src/Commands/ImportDump.php
+++ b/src/Commands/ImportDump.php
@@ -84,6 +84,8 @@ class ImportDump extends Command
         $shouldDownloadDump = $optionRemote || (!$shouldImportLocalDump && $this->userWantsRemoteDump());
 
         if ($shouldDownloadDump) {
+            $this->protector->stopTelescopeRecordingIfEnabled();
+
             $importFilePath = $this->getRemoteDump();
         } elseif ($optionFile) {
             $localFilePath  = $optionFile;

--- a/src/Commands/ImportDump.php
+++ b/src/Commands/ImportDump.php
@@ -84,8 +84,6 @@ class ImportDump extends Command
         $shouldDownloadDump = $optionRemote || (!$shouldImportLocalDump && $this->userWantsRemoteDump());
 
         if ($shouldDownloadDump) {
-            $this->protector->stopTelescopeRecordingIfEnabled();
-
             $importFilePath = $this->getRemoteDump();
         } elseif ($optionFile) {
             $localFilePath  = $optionFile;

--- a/src/Protector.php
+++ b/src/Protector.php
@@ -885,11 +885,11 @@ class Protector
     }
 
     /**
-     * Stops Telescope from recording when telescope is activated.
+     * Stops Telescope from recording when telescope is used.
      */
     public function stopTelescopeRecordingIfEnabled(): void
     {
-        if (class_exists('\Laravel\Telescope\Telescope')) {
+        if (class_exists(Telescope::class)) {
             Telescope::stopRecording();
         }
     }

--- a/src/Protector.php
+++ b/src/Protector.php
@@ -22,7 +22,6 @@ use Illuminate\Support\Facades\App;
 use Illuminate\Support\Facades\Artisan;
 use Illuminate\Support\Facades\Http;
 use Illuminate\Support\Facades\Storage;
-use Laravel\Telescope\Telescope;
 use Psr\Http\Message\StreamInterface;
 use SodiumException;
 use Symfony\Component\Console\Output\BufferedOutput;
@@ -889,8 +888,8 @@ class Protector
      */
     public function stopTelescopeRecordingIfEnabled(): void
     {
-        if (class_exists(Telescope::class)) {
-            Telescope::stopRecording();
+        if (class_exists(\Laravel\Telescope\Telescope::class)) {
+            \Laravel\Telescope\Telescope::stopRecording();
         }
     }
 

--- a/src/Protector.php
+++ b/src/Protector.php
@@ -22,6 +22,7 @@ use Illuminate\Support\Facades\App;
 use Illuminate\Support\Facades\Artisan;
 use Illuminate\Support\Facades\Http;
 use Illuminate\Support\Facades\Storage;
+use Laravel\Telescope\Telescope;
 use Psr\Http\Message\StreamInterface;
 use SodiumException;
 use Symfony\Component\Console\Output\BufferedOutput;
@@ -277,6 +278,8 @@ class Protector
     public function getRemoteDump(): string
     {
         $disk = $this->getDisk();
+
+        $this->stopTelescopeRecordingIfEnabled();
 
         if (App::environment('production')) {
             throw new InvalidEnvironmentException('Retrieving a dump is not allowed on production systems.');
@@ -878,6 +881,16 @@ class Protector
     {
         if (!function_exists('exec')) {
             throw new ShellAccessDeniedException();
+        }
+    }
+
+    /**
+     * Stops Telescope from recording when telescope is activated.
+     */
+    public function stopTelescopeRecordingIfEnabled(): void
+    {
+        if (class_exists('\Laravel\Telescope\Telescope')) {
+            Telescope::stopRecording();
         }
     }
 


### PR DESCRIPTION
This pull request fixes the bug that Telescope purges the response to the request and the user would get an empty dump. Now when we discover that Telescope is being used, we stop Telescope from recording.