### PR TITLE
[2.x] Add support for laravel/sanctum ^3.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -262,6 +262,13 @@ See [cybex-gmbh/collector](https://github.com/cybex-gmbh/collector) for an examp
 
 ## Migration guide from Protector v1.x to v2.x
 
+Likelihood of impact: high
+
+- If your app does not explicitly require the laravel/sanctum package, upgrading Protector to version 2.x may also 
+upgrade Sanctum to version 3.x. This will require you to follow its 
+[upgrade guide](https://github.com/laravel/sanctum/blob/3.x/UPGRADE.md). Alternatively you can explicitly require 
+laravel/sanctum ^2.4 in your app to lock its version.
+
 Likelihood of impact: low
 
 - Access to the formerly public methods getGitRevision(), getGitHeadDate() or getGitBranch() is now protected.

--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,7 @@
         "guzzlehttp/guzzle": "^7.4",
         "illuminate/support": "^8.0|^9.0",
         "laravel/framework": "^8.0|^9.0",
-        "laravel/sanctum": "^2.4",
+        "laravel/sanctum": "^2.4|^3.0",
         "ext-pdo": "*"
     },
     "require-dev": {


### PR DESCRIPTION
This PR will add support for version 3 of Sanctum, which is used when creating new Laravel apps by default. Because Protector only supported ^2.4, the attempt to use Protector in new Laravel projects will produce a composer conflict.

As it seems from reading https://github.com/laravel/sanctum/releases, Sanctum 3 mainly just dropped support for older Laravel versions, but did not introduce breaking changes besides https://github.com/laravel/sanctum/pull/252, that requires an extra expires_at column for personal access tokens. As this is the obligation of the app developers using Protector and Protector is not actively managing that itself, we should be good.