### PR TITLE
Fix empty env key in remote dump test

### DIFF
--- a/Tests/RemoteDumpTest.php
+++ b/Tests/RemoteDumpTest.php
@@ -107,7 +107,7 @@ class RemoteDumpTest extends BaseTest
     {
         Config::set('protector.routeMiddleware', ['auth:sanctum']);
 
-        $this->protector->setPrivateKeyName('');
+        $this->protector->setPrivateKeyName('NON_EXISTENT_PRIVATE_KEY_NAME');
 
         Http::fake([
             $this->serverUrl => Http::response(),


### PR DESCRIPTION
This PR fixes an issue where the failWhenPrivateKeyIsNotSet test in RemoteDumpTest set an empty string for the name env key. 
It seems like DotEnv previously silently accepted that, but now throws an InvalidArgumentException.