### PR TITLE
[2.x] Use Laravel's SchemaState for creating dumps

### DIFF
--- a/Tests/ExportDumpTest.php
+++ b/Tests/ExportDumpTest.php
@@ -107,22 +107,10 @@ class ExportDumpTest extends BaseTest
         ]);
 
         // Configure protector to the invalid database connection.
-        $this->protector->configure('invalid');
+        $this->protector->withConnectionName('invalid');
 
         // Expect an exception when trying to connect and determine if the connected database is a MariaDB database.
         $this->expectException(PDOException::class);
         $this->runProtectedMethod('generateDump', [['no-data' => true]]);
-    }
-
-    /**
-     * @test
-     */
-    public function failOnDumpHasNoConnectionConfigured()
-    {
-        Config::set('database.connections', null);
-        $this->protector->configure();
-
-        $this->expectException(InvalidConnectionException::class);
-        $this->protector->createDump();
     }
 }

--- a/Tests/ImportDumpCommandTest.php
+++ b/Tests/ImportDumpCommandTest.php
@@ -83,7 +83,7 @@ class ImportDumpCommandTest extends BaseTest
     {
         Config::set('database.connections', null);
 
-        $this->expectException(InvalidConfigurationException::class);
+        $this->expectException(InvalidConnectionException::class);
 
         $this->artisan('protector:import');
     }

--- a/Tests/ImportDumpTest.php
+++ b/Tests/ImportDumpTest.php
@@ -153,10 +153,8 @@ class ImportDumpTest extends BaseTest
     public function failOnInvalidConnectionConfig()
     {
         Config::set('database.connections', null);
-        $this->protector->configure();
-
         $this->expectException(InvalidConnectionException::class);
-        $this->protector->importDump($this->filePath);
+        $this->protector->withConnectionName(null);
     }
 
     /**
@@ -178,7 +176,7 @@ class ImportDumpTest extends BaseTest
         Config::set('database.default', 'mysql');
         Config::set('database.connections.mysql.host', 'protector.invalid');
 
-        $this->protector->configure();
+        $this->protector->withConnectionName(null);
 
         $this->expectException(FailedMysqlCommandException::class);
         $this->protector->importDump($this->filePath);

--- a/Tests/RemoteDumpTest.php
+++ b/Tests/RemoteDumpTest.php
@@ -318,21 +318,9 @@ class RemoteDumpTest extends BaseTest
     public function canReturnDatabaseName()
     {
         Config::set('database.connections.mysql.database', __FUNCTION__);
-        $this->protector->configure();
+        $this->protector->withConnectionName();
 
         $this->assertEquals(__FUNCTION__, $this->protector->getDatabaseName());
-    }
-
-    /**
-     * @test
-     */
-    public function failOnNoDatabaseConnectionIsSet()
-    {
-        Config::set('database.connections', null);
-
-        $result = $this->protector->configure();
-
-        $this->assertFalse($result);
     }
 
     /**
@@ -409,7 +397,8 @@ class RemoteDumpTest extends BaseTest
      */
     public function setAuthToken()
     {
-        $this->runProtectedMethod('setAuthToken', [__FUNCTION__]);
+        $this->protector->withAuthToken(__FUNCTION__);
+
         $authToken = $this->runProtectedMethod('getAuthToken');
 
         $this->assertEquals(__FUNCTION__, $authToken);
@@ -420,7 +409,8 @@ class RemoteDumpTest extends BaseTest
      */
     public function setAuthTokenKeyName()
     {
-        $this->runProtectedMethod('setAuthTokenKeyName', [__FUNCTION__]);
+        $this->protector->withAuthTokenKeyName(__FUNCTION__);
+
         $authTokenKeyName = $this->runProtectedMethod('getAuthTokenKeyName');
 
         $this->assertEquals(__FUNCTION__, $authTokenKeyName);

--- a/Tests/RemoteDumpTest.php
+++ b/Tests/RemoteDumpTest.php
@@ -107,7 +107,7 @@ class RemoteDumpTest extends BaseTest
     {
         Config::set('protector.routeMiddleware', ['auth:sanctum']);
 
-        $this->protector->setPrivateKeyName('NON_EXISTENT_PRIVATE_KEY_NAME');
+        $this->protector->withPrivateKeyName('NON_EXISTENT_PRIVATE_KEY_NAME');
 
         Http::fake([
             $this->serverUrl => Http::response(),
@@ -367,7 +367,7 @@ class RemoteDumpTest extends BaseTest
      */
     public function validateUsersPrivateKeyName()
     {
-        $this->protector->setPrivateKeyName(__FUNCTION__);
+        $this->protector->withPrivateKeyName(__FUNCTION__);
         $privateKeyName = $this->protector->getPrivateKeyName();
 
         $this->assertEquals(__FUNCTION__, $privateKeyName);

--- a/src/Classes/AbstractMySqlSchemaStateProxy.php
+++ b/src/Classes/AbstractMySqlSchemaStateProxy.php
@@ -10,9 +10,7 @@ use Illuminate\Database\Schema\SchemaState;
 use Symfony\Component\Process\Process;
 
 /**
- * This is a proxy class to the MySqlSchemaState class to be able to override methods to match our requirements.
- * Unfortunately, the class can not be switched out on framework level, because it is not pulled from the IOC.
- * However, you may extend this class, and override the app container binding with your own implementation.
+ * This abstract class provides proxies to protected methods within the related MySqlSchemaState.
  */
 abstract class AbstractMySqlSchemaStateProxy extends MySqlSchemaState
 {

--- a/src/Classes/AbstractMySqlSchemaStateProxy.php
+++ b/src/Classes/AbstractMySqlSchemaStateProxy.php
@@ -1,0 +1,63 @@
+<?php
+
+namespace Cybex\Protector\Classes;
+
+use Cybex\Protector\Protector;
+use Exception;
+use Illuminate\Database\Connection;
+use Illuminate\Database\Schema\MySqlSchemaState;
+use Illuminate\Database\Schema\SchemaState;
+use Symfony\Component\Process\Process;
+
+/**
+ * This is a proxy class to the MySqlSchemaState class to be able to override methods to match our requirements.
+ * Unfortunately, the class can not be switched out on framework level, because it is not pulled from the IOC.
+ * However, you may extend this class, and override the app container binding with your own implementation.
+ */
+abstract class AbstractMySqlSchemaStateProxy extends MySqlSchemaState
+{
+    public function __construct(protected MySqlSchemaState $schemaState, protected Protector $protector)
+    {
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function dump(Connection $connection, $path)
+    {
+        $this->schemaState->dump(...func_get_args());
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function load($path)
+    {
+        $this->schemaState->load(...func_get_args());
+    }
+
+    protected function executeDumpProcess(Process $process, $output, array $variables): Process
+    {
+        return $this->schemaState->executeDumpProcess(...func_get_args());
+    }
+
+    protected function baseDumpCommand(): string
+    {
+        return $this->schemaState->baseDumpCommand();
+    }
+
+    protected function baseVariables(mixed $config): array
+    {
+        return $this->schemaState->baseVariables(...func_get_args());
+    }
+
+    protected function removeAutoIncrementingState(string $path): void
+    {
+        $this->schemaState->removeAutoIncrementingState(...func_get_args());
+    }
+
+    protected function appendMigrationData(string $path): void
+    {
+        $this->schemaState->appendMigrationData(...func_get_args());
+    }
+}

--- a/src/Classes/MySqlSchemaStateProxy.php
+++ b/src/Classes/MySqlSchemaStateProxy.php
@@ -5,9 +5,9 @@ namespace Cybex\Protector\Classes;
 use Illuminate\Database\Connection;
 
 /**
- * This is a proxy class to the MySqlSchemaState class which allows overriding methods to match our requirements.
- * Unfortunately, the class can not be switched out on framework level, because it is not pulled from the IOC.
- * However, you may extend this class, and override its app container binding with your own implementation.
+ * This is a proxy to the MySqlSchemaState class which allows us to override methods to match our own requirements.
+ * Unfortunately, the class is not bound to the IOC container and thus cannot be switched out at framework level.
+ * However, you may extend this proxy, and override its app container binding with your custom implementation.
  */
 class MySqlSchemaStateProxy extends AbstractMySqlSchemaStateProxy
 {

--- a/src/Classes/MySqlSchemaStateProxy.php
+++ b/src/Classes/MySqlSchemaStateProxy.php
@@ -1,0 +1,71 @@
+<?php
+
+namespace Cybex\Protector\Classes;
+
+use Illuminate\Database\Connection;
+
+/**
+ * This is a proxy class to the MySqlSchemaState class which allows overriding methods to match our requirements.
+ * Unfortunately, the class can not be switched out on framework level, because it is not pulled from the IOC.
+ * However, you may extend this class, and override its app container binding with your own implementation.
+ */
+class MySqlSchemaStateProxy extends AbstractMySqlSchemaStateProxy
+{
+    /**
+     * @inheritDoc
+     */
+    public function dump(Connection $connection, $path)
+    {
+        $this->executeDumpProcess(
+            $this->schemaState->makeProcess(
+                $this->getCommandString()
+            ),
+            $this->schemaState->output,
+            array_merge(
+                $this->baseVariables($this->schemaState->connection->getConfig()),
+                ['LARAVEL_LOAD_PATH' => $path,]
+            )
+        );
+
+        if ($this->protector->shouldRemoveAutoIncrementingState()) {
+            $this->removeAutoIncrementingState($path);
+        }
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function load($path)
+    {
+        $this->schemaState->load(...func_get_args());
+    }
+
+    /**
+     * Get the dump command for MySQL as a string.
+     */
+    protected function getCommandString(): string
+    {
+        $command = 'mysqldump '.$this->schemaState->connectionString().' ';
+
+        $conditionalParameters = [
+            '--set-gtid-purged=OFF' => !$this->schemaState->connection->isMaria(),
+            '--no-create-db'        => !$this->protector->shouldCreateDb(),
+            '--skip-comments'       => !$this->protector->shouldDumpComments(),
+            '--skip-set-charset'    => !$this->protector->shouldDumpCharsets(),
+            '--no-data'             => !$this->protector->shouldDumpData(),
+        ];
+
+        $parameters = [
+            '--add-locks',
+            '--routines',
+            '--tz-utc',
+            '--column-statistics=0',
+            '--result-file="${:LARAVEL_LOAD_PATH}"',
+            '--max-allowed-packet='.$this->protector->getMaxPacketLength(),
+            ...array_keys(array_filter($conditionalParameters)),
+            '"${:LARAVEL_LOAD_DATABASE}"',
+        ];
+
+        return $command.implode(' ', $parameters);
+    }
+}

--- a/src/Commands/ExportDump.php
+++ b/src/Commands/ExportDump.php
@@ -52,19 +52,15 @@ class ExportDump extends Command
         $options = [];
         $options['no-data'] = $this->option('no-data') ?: false;
 
-        if ($this->protector->configure($connectionName ?? null)) {
-            $tempFilePath = $this->protector->createDump($options);
+        $this->protector->withConnectionName($connectionName ?? null);
 
-            $this->protector->getDisk()->putFileAs($directory, new File($tempFilePath), $fileName);
-            unlink($tempFilePath);
+        $tempFilePath = $this->protector->createDump($options);
 
-            $this->info(sprintf('Dump %s was created in %s', $fileName, $directory));
+        $this->protector->getDisk()->putFileAs($directory, new File($tempFilePath), $fileName);
+        unlink($tempFilePath);
 
-            return self::SUCCESS;
-        }
+        $this->info(sprintf('Dump %s was created in %s', $fileName, $directory));
 
-        $this->error('Configuration is invalid.');
-
-        return self::FAILURE;
+        return self::SUCCESS;
     }
 }

--- a/src/Commands/ImportDump.php
+++ b/src/Commands/ImportDump.php
@@ -154,8 +154,6 @@ class ImportDump extends Command
     /**
      * Checks if a dump with the specified name exists and return the file path.
      *
-     * @param string $dumpName
-     * @return string
      * @throws FileNotFoundException
      * @throws InvalidConfigurationException
      */
@@ -173,9 +171,6 @@ class ImportDump extends Command
 
     /**
      * Returns the file path to a selected dump.
-     *
-     * @param string|null $connectionName
-     * @return string
      */
     protected function chooseImportDump(?string $connectionName): string
     {
@@ -200,9 +195,6 @@ class ImportDump extends Command
 
     /**
      * Reads the metadata and returns a list of the available dumps.
-     *
-     * @param array $directoryFiles
-     * @return Collection
      */
     public function getMetaDataForFiles(array $directoryFiles): Collection
     {
@@ -273,10 +265,6 @@ class ImportDump extends Command
 
     /**
      * Imports the selected SQL dump.
-     *
-     * @param string $importFilePath
-     * @param bool|null $optionForce
-     * @return void
      */
     public function importDump(string $importFilePath, ?bool $optionForce): void
     {
@@ -355,9 +343,6 @@ class ImportDump extends Command
     /**
      * Returns the connection name for dump imports.
      * Asks the user if there are multiple possibilities.
-     *
-     * @param Collection $connectionNames
-     * @return string
      */
     protected function chooseConnectionName(Collection $connectionNames): string
     {

--- a/src/Commands/ImportDump.php
+++ b/src/Commands/ImportDump.php
@@ -80,7 +80,7 @@ class ImportDump extends Command
             return self::FAILURE;
         }
 
-        $this->setConnection($optionConnection);
+        $this->protector->withConnectionName($optionConnection);
 
         $shouldImportLocalDump = $optionFile || $optionDump || $optionLatest;
         $shouldDownloadDump = $optionRemote || (!$shouldImportLocalDump && $this->userWantsRemoteDump());
@@ -115,20 +115,6 @@ class ImportDump extends Command
         }
 
         return self::SUCCESS;
-    }
-
-    /**
-     * Sets the given connection.
-     *
-     * @param string|null $connectionName
-     * @return void
-     * @throws InvalidConfigurationException
-     */
-    public function setConnection(?string $connectionName): void
-    {
-        if (!$this->protector->configure($connectionName)) {
-            throw new InvalidConfigurationException('Configuration is invalid');
-        }
     }
 
     /**

--- a/src/Exceptions/UnsupportedDatabaseException.php
+++ b/src/Exceptions/UnsupportedDatabaseException.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Cybex\Protector\Exceptions;
+
+use Exception;
+
+/**
+ * Class UnsupportedDatabaseException
+ *
+ * Thrown if Protector is run in an unsupported database environment.
+ *
+ * @package Cybex\Protector\Exceptions
+ */
+class UnsupportedDatabaseException extends Exception
+{
+    //
+}

--- a/src/Protector.php
+++ b/src/Protector.php
@@ -61,11 +61,6 @@ class Protector
     /**
      * Imports a specific SQL dump.
      *
-     * @param  string  $sourceFilePath
-     * @param  array  $options
-     *
-     * @return void
-     *
      * @throws FailedMysqlCommandException
      * @throws InvalidEnvironmentException
      * @throws InvalidConnectionException

--- a/src/Protector.php
+++ b/src/Protector.php
@@ -768,8 +768,8 @@ class Protector
     {
         return match (get_class($schemaState)) {
             MySqlSchemaState::class => app(MySqlSchemaStateProxy::class, [$schemaState, $this]),
-            PostgresSchemaState::class => app('PostgresSchemaStateProxy', [$schemaState, $this]),
-            SqliteSchemaState::class => app('SqliteSchemaStateProxy', [$schemaState, $this]),
+//            PostgresSchemaState::class => app('PostgresSchemaStateProxy', [$schemaState, $this]),
+//            SqliteSchemaState::class => app('SqliteSchemaStateProxy', [$schemaState, $this]),
             default => throw new UnsupportedDatabaseException('Unsupported database schema state: '.class_basename($schemaState)),
         };
     }

--- a/src/Protector.php
+++ b/src/Protector.php
@@ -19,9 +19,7 @@ use GuzzleHttp\Psr7\StreamWrapper;
 use Illuminate\Contracts\Filesystem\Filesystem;
 use Illuminate\Database\Connection;
 use Illuminate\Database\Schema\MySqlSchemaState;
-use Illuminate\Database\Schema\PostgresSchemaState;
 use Illuminate\Database\Schema\SchemaState;
-use Illuminate\Database\Schema\SqliteSchemaState;
 use Illuminate\Filesystem\FilesystemAdapter;
 use Illuminate\Http\Client\PendingRequest;
 use Illuminate\Http\Request;
@@ -51,7 +49,6 @@ class Protector
      * @var array
      */
     protected array $metaDataCache = [];
-
 
     public function __construct(string $connectionName = null)
     {
@@ -410,9 +407,9 @@ class Protector
             $this->guardExecEnabled();
 
             $gitInformation = [
-            'gitRevision'     => $this->getGitRevision(),
-            'gitBranch'       => $this->getGitBranch(),
-            'gitRevisionDate' => $this->getGitHeadDate(),
+                'gitRevision'     => $this->getGitRevision(),
+                'gitBranch'       => $this->getGitBranch(),
+                'gitRevisionDate' => $this->getGitHeadDate(),
             ];
         }
 

--- a/src/Protector.php
+++ b/src/Protector.php
@@ -767,7 +767,7 @@ class Protector
     protected function getProxyForSchemaState($schemaState): SchemaState
     {
         return match (get_class($schemaState)) {
-            MySqlSchemaState::class => app(MySQLSchemaStateProxy::class, [$schemaState, $this]),
+            MySqlSchemaState::class => app(MySqlSchemaStateProxy::class, [$schemaState, $this]),
             PostgresSchemaState::class => app('PostgresSchemaStateProxy', [$schemaState, $this]),
             SqliteSchemaState::class => app('SqliteSchemaStateProxy', [$schemaState, $this]),
             default => throw new UnsupportedDatabaseException('Unsupported database schema state: '.class_basename($schemaState)),

--- a/src/ProtectorServiceProvider.php
+++ b/src/ProtectorServiceProvider.php
@@ -2,6 +2,7 @@
 
 namespace Cybex\Protector;
 
+use Cybex\Protector\Classes\MySqlSchemaStateProxy;
 use Cybex\Protector\Commands\CreateKeys;
 use Cybex\Protector\Commands\CreateToken;
 use Cybex\Protector\Commands\ExportDump;
@@ -41,12 +42,17 @@ class ProtectorServiceProvider extends ServiceProvider
      */
     public function register(): void
     {
-        // Automatically apply the package configuration
+        // Automatically apply the package configuration.
         $this->mergeConfigFrom(__DIR__ . '/../config/protector.php', 'protector');
 
-        // Register the main class to use with the facade
+        // Register the main class to use with the facade.
         $this->app->singleton('protector', function () {
             return new Protector;
+        });
+
+        // Register the SchemaState proxy classes.
+        $this->app->bind(MySQLSchemaStateProxy::class, function ($app, array $params) {
+            return new MySqlSchemaStateProxy(...$params);
         });
     }
 

--- a/src/ProtectorServiceProvider.php
+++ b/src/ProtectorServiceProvider.php
@@ -51,7 +51,7 @@ class ProtectorServiceProvider extends ServiceProvider
         });
 
         // Register the SchemaState proxy classes.
-        $this->app->bind(MySQLSchemaStateProxy::class, function ($app, array $params) {
+        $this->app->bind(MySqlSchemaStateProxy::class, function ($app, array $params) {
             return new MySqlSchemaStateProxy(...$params);
         });
     }

--- a/src/Traits/HasConfiguration.php
+++ b/src/Traits/HasConfiguration.php
@@ -1,0 +1,271 @@
+<?php
+
+namespace Cybex\Protector\Traits;
+
+use Cybex\Protector\Exceptions\InvalidConnectionException;
+
+trait HasConfiguration
+{
+    /**
+     * Cache for the current connection-name.
+     */
+    protected string $connectionName;
+
+    /**
+     * Cache for the current connection-configuration.
+     */
+    protected mixed $connectionConfig;
+
+    /**
+     * Defines whether dumps should include a DB creation statement.
+     */
+    protected bool $createDb = true;
+
+    /**
+     * The name of the .env key for the Protector DB Token.
+     */
+    protected string $authTokenKeyName = 'PROTECTOR_AUTH_TOKEN';
+
+    /**
+     * The name of the .env key for the Protector Private Key.
+     */
+    protected string $privateKeyName = 'PROTECTOR_PRIVATE_KEY';
+
+    /**
+     * The server url for the dump endpoint.
+     */
+    protected string $serverUrl = '';
+
+    /**
+     * The Protector Auth Token.
+     */
+    protected string $authToken = '';
+
+    /**
+     * The maximum packet length for the dump.
+     */
+    protected string $maxPacketLength;
+
+    /**
+     * If set to false, the --no-tablespaces dump option will be used in MySQL.
+     */
+    protected bool $tablespaces = true;
+
+    /**
+     * Specifies whether comments should be added to the dump file.
+     */
+    protected bool $dumpComments = true;
+
+    /**
+     * If false, no SET NAMES statements will be written to the dump.
+     */
+    protected bool $dumpCharsets = true;
+
+    /**
+     * Specifies whether table data should be dumped.
+     */
+    protected bool $dumpData = true;
+
+    /**
+     * If true, the auto increment state will be stripped from the dump.
+     */
+    protected bool $removeAutoIncrementingState = false;
+
+
+    /**
+     * Sets the auth token for Laravel Sanctum authentication.
+     */
+    public function withAuthToken(string $authToken): static
+    {
+        $this->authToken = $authToken;
+
+        return $this;
+    }
+
+    /**
+     * Sets the name of the .env key for the Protector DB Token.
+     */
+    public function withAuthTokenKeyName(string $authTokenKeyName): static
+    {
+        $this->authTokenKeyName = $authTokenKeyName;
+
+        return $this;
+    }
+
+    public function withoutAutoIncrementingState(): static
+    {
+        $this->removeAutoIncrementingState = true;
+
+        return $this;
+    }
+
+    public function withoutCharsets(): static
+    {
+        $this->dumpCharsets = false;
+
+        return $this;
+    }
+
+    public function withoutComments(): static
+    {
+        $this->dumpComments = false;
+
+        return $this;
+    }
+
+    public function withoutData(): static
+    {
+        $this->dumpData = false;
+
+        return $this;
+    }
+
+    /**
+     * @throws InvalidConnectionException
+     */
+    public function withConnectionName(string $connectionName = null): static
+    {
+        $this->connectionName = $connectionName ?? config('database.default');
+
+        if (($this->connectionConfig = $this->getDatabaseConfig()) === false) {
+            throw new InvalidConnectionException('Invalid database configuration');
+        }
+
+        return $this;
+    }
+
+    public function withoutCreateDb(): static
+    {
+        $this->createDb = false;
+
+        return $this;
+    }
+
+    public function withoutTablespaces(): static
+    {
+        $this->tablespaces = false;
+
+        return $this;
+    }
+
+
+    public function withMaxPacketLength(string $maxPacketLength): static
+    {
+        $this->maxPacketLength = $maxPacketLength;
+
+        return $this;
+    }
+
+    public function withDefaultMaxPacketLength(): static
+    {
+        $this->maxPacketLength = config('protector.maxPacketLength');
+
+        return $this;
+    }
+
+    /**
+     * Sets the name of the .env key for the Protector Crypto Key.
+     */
+    public function withPrivateKeyName(string $privateKeyName): static
+    {
+        $this->privateKeyName = $privateKeyName;
+
+        return $this;
+    }
+
+    /**
+     * Sets the server url of the dump endpoint.
+     */
+    public function withServerUrl(string $serverUrl): static
+    {
+        $this->serverUrl = $serverUrl;
+
+        return $this;
+    }
+
+    /**
+     * Retrieves the auth token for Laravel Sanctum authentication.
+     */
+    protected function getAuthToken(): string
+    {
+        return $this->authToken ?: env($this->authTokenKeyName, '');
+    }
+
+    /**
+     * Gets the name of the .env key for the Protector DB Token.
+     */
+    public function getAuthTokenKeyName(): string
+    {
+        return $this->authTokenKeyName;
+    }
+
+    /**
+     * Returns the database config for the given connection.
+     */
+    protected function getDatabaseConfig(): mixed
+    {
+        return config(sprintf('database.connections.%s', $this->connectionName), false);
+    }
+
+    /**
+     * Returns the database name specified in the connectionConfig array.
+     */
+    public function getDatabaseName(): string
+    {
+        return $this->connectionConfig['database'];
+    }
+
+    public function getMaxPacketLength(): string
+    {
+        return $this->maxPacketLength;
+    }
+
+    /**
+     * Sets the name of the .env key for the Protector Crypto Key.
+     */
+    public function getPrivateKeyName(): string
+    {
+        return $this->privateKeyName;
+    }
+
+    /**
+     * Retrieves the private key for Sodium encryption.
+     */
+    protected function getPrivateKey(): string
+    {
+        return env($this->privateKeyName, '');
+    }
+
+    /**
+     * Retrieves the server url of the dump endpoint.
+     */
+    public function getServerUrl(): string
+    {
+        return $this->serverUrl ?: $this->getConfigValueForKey('remoteEndpoint.serverUrl');
+    }
+
+    public function shouldDumpCharsets(): bool
+    {
+        return $this->dumpCharsets;
+    }
+
+    public function shouldDumpComments(): bool
+    {
+        return $this->dumpComments;
+    }
+
+    public function shouldCreateDb(): bool
+    {
+        return $this->createDb;
+    }
+
+    public function shouldDumpData(): bool
+    {
+        return $this->dumpData;
+    }
+
+    public function shouldRemoveAutoIncrementingState(): bool
+    {
+        return $this->removeAutoIncrementingState;
+    }
+}


### PR DESCRIPTION
This PR resolves #42 by replacing the dump creation logic with using the SchemaState classes from the Laravel framework.
This iteration only supports MySQL databases, and should be used to discuss the approach and get things right before implementing support for PostgreSQL and SQLite.

The default SchemaState classes create dumps that are highly opinionated and do not dump table data, so we have to override the dump method in order to pass our own set of options.

As it turned out in the end, there is not much left that we use of the framework code, but we potentially don't want to pull in any framework changes in the parts we replaced anyways. The approach allows developers to override the classes with their own implementations in case they want to do other fancy stuff when dumping or restoring.

This PR also applies a number of architectural changes, extracting configuration concerns to the HasConfiguration trait to make the Protector class a little more readable. It could be discussed to use a separate configuration class instead, since the trait will not be reused by any other class.