### PR TITLE
[2.x] Add Laravel 10 compatibility

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -22,8 +22,8 @@ jobs:
         strategy:
             fail-fast: true
             matrix:
-                php: [ 8.0, 8.1, 8.2 ]
-                laravel: [ 8.*, 9.*, 10.* ]
+                php: [ 8.1, 8.2 ]
+                laravel: [ 9.*, 10.* ]
                 dependency-version: [ prefer-stable ]
 
         name: PHP ${{ matrix.php }} with Laravel ${{ matrix.laravel }} (${{ matrix.dependency-version }})

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -22,8 +22,8 @@ jobs:
         strategy:
             fail-fast: true
             matrix:
-                php: [ 8.0, 8.1 ]
-                laravel: [ 8.*, 9.* ]
+                php: [ 8.0, 8.1, 8.2 ]
+                laravel: [ 8.*, 9.*, 10.* ]
                 dependency-version: [ prefer-stable ]
 
         name: PHP ${{ matrix.php }} with Laravel ${{ matrix.laravel }} (${{ matrix.dependency-version }})

--- a/composer.json
+++ b/composer.json
@@ -28,14 +28,14 @@
         "ext-pdo": "*",
         "ext-sodium": "*",
         "guzzlehttp/guzzle": "^7.4",
-        "illuminate/support": "^8.0|^9.0|^10.0",
-        "laravel/framework": "^8.0|^9.0|^10.0",
+        "illuminate/support": "^9.0|^10.0",
+        "laravel/framework": "^9.0|^10.0",
         "laravel/sanctum": "^3.2"
     },
     "require-dev": {
         "laravel/sail": "^1.18",
         "orchestra/testbench": "^6.23|^7.0|^8.0",
-        "phpunit/phpunit": "^9.5"
+        "phpunit/phpunit": "^10.0"
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -21,21 +21,21 @@
         }
     ],
     "require": {
-        "php": "^8.0",
+        "php": "^8.1",
         "ext-curl": "*",
         "ext-json": "*",
         "ext-mbstring": "*",
+        "ext-pdo": "*",
         "ext-sodium": "*",
         "guzzlehttp/guzzle": "^7.4",
-        "illuminate/support": "^8.0|^9.0",
-        "laravel/framework": "^8.0|^9.0",
-        "laravel/sanctum": "^2.4",
-        "ext-pdo": "*"
+        "illuminate/support": "^8.0|^9.0|^10.0",
+        "laravel/framework": "^8.0|^9.0|^10.0",
+        "laravel/sanctum": "^3.2"
     },
     "require-dev": {
-        "laravel/sail": "^1.15",
-        "orchestra/testbench": "^6.23|^7.0",
-        "phpunit/phpunit": "^9.5"
+        "laravel/sail": "^1.18",
+        "orchestra/testbench": "^6.23|^7.0|^8.0",
+        "phpunit/phpunit": "^10.0"
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -35,7 +35,7 @@
     "require-dev": {
         "laravel/sail": "^1.18",
         "orchestra/testbench": "^6.23|^7.0|^8.0",
-        "phpunit/phpunit": "^10.0"
+        "phpunit/phpunit": "^9.5"
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -34,8 +34,8 @@
     },
     "require-dev": {
         "laravel/sail": "^1.18",
-        "orchestra/testbench": "^6.23|^7.0|^8.0",
-        "phpunit/phpunit": "^10.0"
+        "orchestra/testbench": "^7.0|^8.0",
+        "phpunit/phpunit": "^9.5"
     },
     "autoload": {
         "psr-4": {

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,15 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit bootstrap="vendor/autoload.php"
-         backupGlobals="false"
-         backupStaticAttributes="false"
-         colors="true"
-         verbose="true"
-         testdox="true"
-         convertErrorsToExceptions="true"
-         convertNoticesToExceptions="true"
-         convertWarningsToExceptions="true"
-         processIsolation="false"
-         stopOnFailure="false">
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" bootstrap="vendor/autoload.php" backupGlobals="false"
+         colors="true" testdox="true" processIsolation="false" stopOnFailure="false"
+         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/10.0/phpunit.xsd" cacheDirectory=".phpunit.cache"
+         backupStaticProperties="false">
     <testsuites>
         <testsuite name="Test Suite">
             <directory>Tests</directory>


### PR DESCRIPTION
This PR adds Laravel 10 support.

Since Laravel 10 now has the mininum requirement of PHP 8.1 and Protector previously supported PHP 8.0, this is a breaking change. Please also see the older PR #57.

Also, Laravel 8 support has to be dropped, because it will not support Sanctum 3.2, which is required by Laravel 10. PHPUnit has to stay at version 9, because only Laravel 10 supports it.

Thus, this needs to be tagged as a new major version 2.0. 