### PR TITLE
[2.x] Fix crash on file download responses

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -56,6 +56,6 @@ jobs:
                     composer require "laravel/framework:${{ matrix.laravel }}" --no-interaction --no-update --dev --no-progress
                     composer update --${{ matrix.dependency-version }} --prefer-dist --no-interaction --no-progress
             -   name: Execute tests
-                run: vendor/bin/phpunit
+                run: vendor/bin/phpunit -c phpunit-ci.xml.dist
                 env:
                     DB_PORT: ${{ job.services.mysql.ports[3306] }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -16,6 +16,7 @@ jobs:
                 image: mysql:8.0
                 env:
                     MYSQL_ALLOW_EMPTY_PASSWORD: yes
+                    MYSQL_DATABASE: protector_test
                 ports:
                     - 3306
                 options: --health-cmd="mysqladmin ping" --health-interval=10s --health-timeout=5s --health-retries=3

--- a/Tests/ExportDumpTest.php
+++ b/Tests/ExportDumpTest.php
@@ -1,11 +1,12 @@
 <?php
 
 use Cybex\Protector\Exceptions\FailedCreatingDestinationPathException;
-use Cybex\Protector\Exceptions\InvalidConnectionException;
 use Illuminate\Contracts\Filesystem\Filesystem;
+use Illuminate\Http\Request;
 use Illuminate\Support\Carbon;
 use Illuminate\Support\Facades\Config;
 use Illuminate\Support\Facades\Storage;
+use Symfony\Component\HttpFoundation\StreamedResponse;
 
 class ExportDumpTest extends BaseTest
 {
@@ -126,5 +127,18 @@ class ExportDumpTest extends BaseTest
         // Expect an exception when trying to connect and determine if the connected database is a MariaDB database.
         $this->expectException(PDOException::class);
         $this->runProtectedMethod('generateDump', [['no-data' => true]]);
+    }
+
+    /**
+     * @test
+     */
+    public function createsStreamedFileDownloadResponse()
+    {
+        Config::set('protector.routeMiddleware', []);
+
+        $response = $this->protector->generateFileDownloadResponse(new Request(), null);
+
+        $this->assertInstanceOf(StreamedResponse::class, $response);
+        $this->assertEquals(200, $response->getStatusCode());
     }
 }

--- a/phpunit-ci.xml.dist
+++ b/phpunit-ci.xml.dist
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" bootstrap="vendor/autoload.php" backupGlobals="false"
+         colors="true" testdox="true" processIsolation="false" stopOnFailure="false"
+         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/10.0/phpunit.xsd">
+    <testsuites>
+        <testsuite name="Test Suite">
+            <directory>Tests</directory>
+        </testsuite>
+    </testsuites>
+    <coverage>
+        <include>
+            <directory suffix=".php">./src</directory>
+        </include>
+        <report>
+            <html outputDirectory="build/coverage"/>
+            <text outputFile="build/coverage.txt"/>
+            <clover outputFile="build/logs/clover.xml"/>
+        </report>
+    </coverage>
+    <logging>
+        <junit outputFile="build/report.junit.xml"/>
+    </logging>
+    <php>
+        <env name="PROTECTOR_PRIVATE_KEY"
+             value="e195f1252346e31fe7b87e899f69a87d6fe99f38bd6e7c3cbdde411fcd9cc93e2c1d0ea6e0f8e207b38bef11bfcd5c0615c3cf4695876631b1da523a552b6022"/>
+        <env name="PROTECTOR_PUBLIC_KEY" value="2c1d0ea6e0f8e207b38bef11bfcd5c0615c3cf4695876631b1da523a552b6022"/>
+        <env name="PROTECTOR_ENCRYPTED_MESSAGE"
+             value="c93e1c30857b0a5a36dddd11237ff65ef153144e0c400304cc80501da7e9b41a99c568fb34491629577ba4b5c0ec632e50067d61cf1ece27e1eabc"/>
+        <env name="PROTECTOR_DECRYPTED_MESSAGE" value="hello world"/>
+        <env name="PROTECTOR_AUTH_TOKEN" value="1|bxa5BBNo7lXxgtRY4DN775JdAtQSAlN4UfgRnFhz"/>
+        <env name="DB_HOST" value="127.0.0.1"/>
+        <env name="DB_DATABASE" value="protector_test"/>
+        <env name="DB_USERNAME" value="root"/>
+        <env name="DB_PASSWORD" value=""/>
+        <env name="APP_URL" value="http://protector.invalid"/>
+    </php>
+</phpunit>

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,8 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" bootstrap="vendor/autoload.php" backupGlobals="false"
          colors="true" testdox="true" processIsolation="false" stopOnFailure="false"
-         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/10.0/phpunit.xsd" cacheDirectory=".phpunit.cache"
-         backupStaticProperties="false">
+         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/10.0/phpunit.xsd">
     <testsuites>
         <testsuite name="Test Suite">
             <directory>Tests</directory>

--- a/src/Protector.php
+++ b/src/Protector.php
@@ -490,7 +490,7 @@ class Protector
         $shouldEncrypt = $this->shouldEncrypt();
 
         // Only proceed when either Laravel Sanctum is turned off or the user's token is valid.
-        if (!$shouldEncrypt || $request->user()->tokenCan('protector:import')) {
+        if (!$shouldEncrypt || $request->user()?->tokenCan('protector:import')) {
             if ($this->withConnectionName($connectionName)) {
                 try {
                     $serverFilePath = $this->createDump();
@@ -647,7 +647,7 @@ class Protector
     protected function getPublicKey(Request $request): string
     {
         try {
-            $publicKey = sodium_hex2bin($request->user()->protector_public_key);
+            $publicKey = sodium_hex2bin($request->user()?->protector_public_key);
         } catch (SodiumException) {
             throw new InvalidConfigurationException(
                 'There was an error receiving the crypto keys. This might be due to mismatching crypto keys.'

--- a/src/Protector.php
+++ b/src/Protector.php
@@ -491,7 +491,7 @@ class Protector
 
         // Only proceed when either Laravel Sanctum is turned off or the user's token is valid.
         if (!$shouldEncrypt || $request->user()->tokenCan('protector:import')) {
-            if ($this->configure($connectionName)) {
+            if ($this->withConnectionName($connectionName)) {
                 try {
                     $serverFilePath = $this->createDump();
                     $publicKey      = $this->getPublicKey($request);


### PR DESCRIPTION
This PR fixes a crash that occurs when the server tries to prepare a download response.
The code still calls the removed `configure()` method that has been replaced with `withConnectionName()` in 2.0.

It also adds a test to make sure a proper streamedResponse is generated.