### PR TITLE
remove a false statement from the readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -264,10 +264,9 @@ See [cybex-gmbh/collector](https://github.com/cybex-gmbh/collector) for an examp
 
 Likelihood of impact: high
 
-- If your app does not explicitly require the laravel/sanctum package, upgrading Protector to version 2.x may also 
+- If your app does not explicitly require the laravel/sanctum package, upgrading Protector to version 2.x will also 
 upgrade Sanctum to version 3.x. This will require you to follow its 
-[upgrade guide](https://github.com/laravel/sanctum/blob/3.x/UPGRADE.md). Alternatively you can explicitly require 
-laravel/sanctum ^2.4 in your app to lock its version.
+[upgrade guide](https://github.com/laravel/sanctum/blob/3.x/UPGRADE.md).
 
 Likelihood of impact: low
 


### PR DESCRIPTION
## **Type**
documentation


___

## **Description**
- This PR updates the README to provide clearer instructions on upgrading Sanctum when moving from Protector v1.x to v2.x.
- It removes the previously misleading suggestion to lock the version of `laravel/sanctum`, simplifying the upgrade guidance.



___



## **Changes walkthrough**
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>README.md</strong><dd><code>Update and Clarify Sanctum Upgrade Information in README</code>&nbsp; </dd></summary>
<hr>
      
README.md

<li>Removed misleading information about needing to lock the version of <br><code>laravel/sanctum</code> when upgrading Protector.<br> <li> Clarified the upgrade process by simplifying the statement about <br>Sanctum upgrade requirements.<br>


</details>
    

  </td>
  <td><a href="https://github.com/cybex-gmbh/laravel-protector/pull/87/files#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5">+2/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> ✨ **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

