### PR TITLE
disable composer security checking

### DIFF
--- a/.github/workflows/tests-matrix.yml
+++ b/.github/workflows/tests-matrix.yml
@@ -50,7 +50,7 @@ jobs:
                         laravel: 11.*
                     -   php: 8.1
                         laravel: 12.*
-        uses: cybex-gmbh/github-workflows/.github/workflows/tests.yml@feature/disable-composer-audit
+        uses: cybex-gmbh/github-workflows/.github/workflows/tests.yml@main
         with:
             DATABASE_IMAGE: ${{ inputs.DATABASE_IMAGE }}
             DATABASE_CLIENT_VERSION: ${{ inputs.DATABASE_CLIENT_VERSION }}
@@ -64,6 +64,3 @@ jobs:
             LARAVEL_VERSION: ${{ matrix.laravel }}
             DEPENDENCY_VERSION: ${{ matrix.dependency-version }}
             TEST_COMMANDS: vendor/bin/phpunit -c phpunit-ci.xml.dist
-            # We disable composer audits, as vulnerabilities would block the development of this package, even when we are not explicitly requiring anything on our own.
-            # The project requiring our package should be responsible for evaluating possible vulnerabilities.
-            DISABLE_COMPOSER_AUDIT: true

--- a/README.md
+++ b/README.md
@@ -297,6 +297,11 @@ No breaking changes are expected.
 composer install
 ```
 
+> [!NOTE]
+> We disable composer security checking for this package, as vulnerabilities would block the development.
+> The project requiring our package should be responsible for evaluating possible vulnerabilities. 
+> For more information, see the [composer documentation](https://getcomposer.org/doc/06-config.md#block-insecure).
+
 ### Testing
 
 Run tests on MySQL database:

--- a/composer.json
+++ b/composer.json
@@ -58,7 +58,10 @@
         "test-coverage": "vendor/bin/phpunit --coverage-html coverage"
     },
     "config": {
-        "sort-packages": true
+        "sort-packages": true,
+        "audit": {
+            "block-insecure": false
+        }
     },
     "extra": {
         "laravel": {


### PR DESCRIPTION
We disable composer security checking as unpatched vulnerabilities would block the development of the package. 

This does not disable security checking for apps requiring this package. They can then decide for themselves how they are going to proceed.

This has become an issue due to Laravel 9 having unpatched vulnerabilities, such as [PKSA-8qx3-n5y5-vvnd](https://packagist.org/security-advisories/PKSA-8qx3-n5y5-vvnd).