### PR TITLE
refactor the protector:import command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ All notable changes to `protector` will be documented in this file.
 
 - The minimum required PHP version is now 8.2
 - Restructured the `protector.php` configuration file for better organization and clarity
+- The `protector:import` command no longer supports the `--dump` option. The `--file` option now accepts both a relative and an absolute path.
 - Reformatted the output of the `protector:keys` and `protector:token` commands to easier spot relevant information
 
 ### Features

--- a/UPGRADE-GUIDE.md
+++ b/UPGRADE-GUIDE.md
@@ -17,6 +17,8 @@
 - To support config caching, .env key names can no longer be changed during runtime.
   If you previously relied on setting .env key names,
   you will now have to set the values directly instead.
+- Some functions throw different or more detailed exceptions.
+- The `protector:import` command no longer supports the `--dump` option.
 
 > [!IMPORTANT]
 > The `protector.php` config structure and keys have changed.
@@ -189,6 +191,24 @@ use the following methods instead:
 
 - Protector::withPrivateKey()
 - Protector::withAuthToken()
+
+### Protector::getLatestDumpName()
+
+> [!NOTE]
+> Likelihood of impact: low
+>
+> Impact: Error handling based on the `FileNotFoundException` will no longer work
+
+The method now throws a `EmptyDumpDirectoryException` instead of a `FileNotFoundException` when no dumps are found in the base directory.
+
+### protector:import command
+
+> [!NOTE]
+> Likelihood of impact: low
+>
+> Impact: Command calls using the `--dump` option will fail
+
+The `protector:import` command no longer supports the `--dump` option. The `--file` option now accepts both a relative and an absolute path.
 
 ---
 

--- a/src/Commands/CreateToken.php
+++ b/src/Commands/CreateToken.php
@@ -29,9 +29,9 @@ class CreateToken extends Command
     /**
      * Execute the console command.
      *
-     * @return void
+     * @return int
      */
-    public function handle(): void
+    public function handle(): int
     {
         $publicKey = $this->option('publicKey');
         $user = config('auth.providers.users.model')::findOrFail($this->argument('userId'));
@@ -42,7 +42,9 @@ class CreateToken extends Command
         $this->warn(sprintf('Executing for User %s|%s (%s)', $user->id, $user->name, $user->email));
 
         if (!$user->protector_public_key && !$publicKey) {
-            $this->fail('The user doesn\'t have a protector public key and none was specified. Please provide a public key for the user.');
+            $this->error('The user doesn\'t have a protector public key and none was specified. Please provide a public key for the user.');
+
+            return self::FAILURE;
         }
 
         if ($publicKey) {
@@ -61,5 +63,7 @@ class CreateToken extends Command
         $this->info(sprintf('%s=%s', app('protector')->getDumpEndpointUrlKeyName(), route('protector.server.dump')));
 
         $this->newLine();
+
+        return self::SUCCESS;
     }
 }

--- a/src/Commands/ImportDump.php
+++ b/src/Commands/ImportDump.php
@@ -57,6 +57,8 @@ class ImportDump extends Command
      */
     public function handle(): int
     {
+        $this->newLine();
+
         if (App::environment('production') && !$this->option('allow-production')) {
             throw new InvalidEnvironmentException(
                 'Import is not allowed on production systems! Use --allow-production'
@@ -75,12 +77,16 @@ class ImportDump extends Command
             return self::FAILURE;
         }
 
-        match (true) {
-            $this->option('remote') => $this->importDumpFromRemote(),
-            $hasFile => $this->importDumpFromFile(),
-            $this->option('latest') => $this->importLatestDump(),
-            default => $this->importInteractive(),
+        $dumpFilePath = match (true) {
+            $this->option('remote') => $this->getDumpFromRemote(),
+            $hasFile => $this->getDumpFromFile(),
+            $this->option('latest') => $this->getLatestDump(),
+            default => $this->getDumpInteractive(),
         };
+
+        $this->prepareAndImportDumpFile($dumpFilePath);
+
+        $this->newLine();
 
         return self::SUCCESS;
     }
@@ -88,7 +94,7 @@ class ImportDump extends Command
     /**
      * Reads the remote dump file and deletes all old dumps if the flush option is set.
      */
-    protected function importDumpFromRemote(): void
+    protected function getDumpFromRemote(): string
     {
         $disk = $this->protector->getDisk();
         $basePath = $this->protector->getBaseDirectory();
@@ -108,8 +114,7 @@ class ImportDump extends Command
             $this->warn(sprintf('Deleted all old files in %s', $absolutePathToBaseDirectory));
         }
 
-        // We need to create a local temp file as the Protector disk might not be a local disk.
-        $this->importDumpFromTempFile($relativeRemoteDumpFilePath);
+        return $relativeRemoteDumpFilePath;
     }
 
     /**
@@ -118,22 +123,18 @@ class ImportDump extends Command
      *
      * @throws FileNotFoundException
      */
-    protected function importDumpFromFile(): void
+    protected function getDumpFromFile(): string
     {
         $isAbsoluteFilePath = $this->isAbsolutePath($this->option('file'));
-        $dumpFilePath = $isAbsoluteFilePath ? $this->option('file') : sprintf('%s%s%s', $this->protector->getBaseDirectory(), DIRECTORY_SEPARATOR, $this->option('file'));
 
         switch ($isAbsoluteFilePath) {
             case true:
-                $fileExists = file_exists($dumpFilePath);
                 $dumpFilePath = $this->option('file');
-                $importFn = fn() => $this->importDump($dumpFilePath, $this->option('force'));
+                $fileExists = file_exists($dumpFilePath);
                 break;
             default:
+                $dumpFilePath = implode(DIRECTORY_SEPARATOR, [$this->protector->getBaseDirectory(), $this->option('file')]);
                 $fileExists = $this->protector->getDisk()->exists($dumpFilePath);
-                $dumpFilePath = sprintf('%s%s%s', $this->protector->getBaseDirectory(), DIRECTORY_SEPARATOR, $this->option('file'));
-                // For relative paths, we need to create a local temp file as the Protector disk might not be a local disk.
-                $importFn = fn() => $this->importDumpFromTempFile($dumpFilePath);
                 break;
         }
 
@@ -141,52 +142,48 @@ class ImportDump extends Command
             throw new FileNotFoundException($dumpFilePath);
         }
 
-        $importFn();
+        // Might be absolute or relative at this point.
+        return $dumpFilePath;
     }
 
-    protected function importLatestDump(): void
+    protected function getLatestDump(): string
     {
         $relativeImportFilePath = $this->protector->getLatestDumpName();
 
         $this->info(sprintf('Importing <comment>%s</comment>', $relativeImportFilePath));
 
-        // We need to create a local temp file as the Protector disk might not be a local disk.
-        $this->importDumpFromTempFile($relativeImportFilePath);
+        return $relativeImportFilePath;
     }
 
-    protected function importInteractive(): void
+    protected function getDumpInteractive(): string
     {
         if ($this->userWantsRemoteDump()) {
-            $this->importDumpFromRemote();
-
-            return;
+            return $this->getDumpFromRemote();
         }
 
-        $relativeImportFilePath = $this->chooseImportDump($this->option('connection'));
-
-        // We need to create a local temp file as the Protector disk might not be a local disk.
-        $this->importDumpFromTempFile($relativeImportFilePath);
+        return $this->chooseImportDump($this->option('connection'));
     }
 
     /**
      * Imports a dump file.
      * If it is stored remotely, a local temporary file is created, imported, and deleted afterward.
      */
-    protected function importDumpFromTempFile(string $dumpFilePath): void
+    protected function prepareAndImportDumpFile(string $dumpFilePath): void
     {
-        if (!is_a($this->protector->getDisk()->getAdapter(), LocalFilesystemAdapter::class)) {
-            $absoluteLocalFilePath = $this->protector->createTempFilePath($dumpFilePath);
-        }
-
-        // We need an absolute file path going forward. The file path may already be absolute, only if called with the --file option and passed an absolute path.
+        // We need an absolute and local file path going forward. The file path may already be absolute and local, only if called with the --file option and passed an absolute path.
         if (!$this->isAbsolutePath($dumpFilePath)) {
-            $dumpFilePath = $this->protector->getDisk()->path($dumpFilePath);
+            // The Protector disk might be local, if not, we need to create a local temp file.
+            if (is_a($this->protector->getDisk()->getAdapter(), LocalFilesystemAdapter::class)) {
+                $dumpFilePath = $this->protector->getDisk()->path($dumpFilePath);
+            } else {
+                $absoluteTempFilePath = $this->protector->createTempFilePath($dumpFilePath);
+            }
         }
 
         try {
-            $this->importDump($absoluteLocalFilePath ?? $dumpFilePath, $this->option('force'));
+            $this->importDump($absoluteTempFilePath ?? $dumpFilePath, $this->option('force'));
         } finally {
-            !empty($absoluteLocalFilePath) && unlink($absoluteLocalFilePath);
+            !empty($absoluteTempFilePath) && unlink($absoluteTempFilePath);
         }
     }
 
@@ -198,8 +195,9 @@ class ImportDump extends Command
         $connectionFiles = $this->getConnectionFiles($connectionName);
 
         if ($connectionFiles->count() === 1) {
-            $importFilePath = $connectionFiles->first()['path'];
-            $this->info(sprintf('Using file "%s" because there are no other dumps.', $importFilePath));
+            $relativeImportFilePath = $connectionFiles->first()['path'];
+
+            $this->info(sprintf('Using file "%s" because there are no other dumps.', $relativeImportFilePath));
         } else {
             $importFile = $this->choice(
                 'Which file do you want to import?',
@@ -208,10 +206,10 @@ class ImportDump extends Command
                 })->toArray()
             );
 
-            $importFilePath = $connectionFiles->firstWhere('file', $importFile)['path'];
+            $relativeImportFilePath = $connectionFiles->firstWhere('file', $importFile)['path'];
         }
 
-        return $importFilePath;
+        return $relativeImportFilePath;
     }
 
     /**

--- a/src/Commands/ImportDump.php
+++ b/src/Commands/ImportDump.php
@@ -5,15 +5,14 @@ namespace Cybex\Protector\Commands;
 use Carbon\Carbon;
 use Cybex\Protector\Exceptions\EmptyBaseDirectoryException;
 use Cybex\Protector\Exceptions\FileNotFoundException;
-use Cybex\Protector\Exceptions\InvalidConfigurationException;
 use Cybex\Protector\Exceptions\InvalidConnectionException;
 use Cybex\Protector\Exceptions\InvalidEnvironmentException;
 use Cybex\Protector\Protector;
-use Exception;
 use Illuminate\Console\Command;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\App;
+use League\Flysystem\Local\LocalFilesystemAdapter;
 
 /**
  * Class ImportDump
@@ -28,11 +27,10 @@ class ImportDump extends Command
      * @var string
      */
     protected $signature = 'protector:import
-                {--d|dump= : The file name in the database dump folder. }
-                {--f|file= : The absolute path and filename to the dump to import. }
+                {--f|file= : Either an absolute path to a file, or a filename relative to the protector dump directory. }
                 {--c|connection= : The configured database-connection in Laravel\'s config/database.php. }
                 {--allow-production : Enable importing SQL dumps on a production system. }
-                {--force : Forces the import of the given file or remote download. Requires the dump, file or remote option. }
+                {--force : Forces the import of the given file or remote download. Requires the file, remote or latest option. }
                 {--i|ignore-connection-filter : Ignores filter of dumps to defined connections. }
                 {--r|remote : Pull a fresh dump from the remote server as configured in the .env file. Will be used as fallback when combined with other options. }
                 {--flush : Delete all existing dumps in the dump folder when using a remote dump. }
@@ -59,115 +57,134 @@ class ImportDump extends Command
      */
     public function handle(): int
     {
-        $this->protector = app('protector');
-
-        $this->protector->guardRequiredFunctionsEnabled();
-
-        $optionDump = $this->option('dump');
-        $optionFile = $this->option('file');
-        $optionRemote = $this->option('remote');
-        $optionForce = $this->option('force');
-        $optionLatest = $this->option('latest');
-        $optionConnection = $this->option('connection');
-
         if (App::environment('production') && !$this->option('allow-production')) {
             throw new InvalidEnvironmentException(
                 'Import is not allowed on production systems! Use --allow-production'
             );
         }
 
-        if ($optionForce && !($optionRemote || $optionFile || $optionDump || $optionLatest)) {
-            $this->error('Nothing to import.');
+        $this->protector = app('protector');
+        $this->protector->guardRequiredFunctionsEnabled();
+        $this->protector->withConnectionName($this->option('connection'));
 
-            return self::FAILURE;
+        $hasFile = !empty(trim($this->option('file')));
+
+        if ($this->option('force') && !($this->option('remote') || $hasFile || $this->option('latest'))) {
+            $this->fail('Nothing to import. You need to specify either --remote, --file, or --latest.');
         }
 
-        $this->protector->withConnectionName($optionConnection);
-
-        $shouldImportLocalDump = $optionFile || $optionDump || $optionLatest;
-        $shouldDownloadDump = $optionRemote || (!$shouldImportLocalDump && $this->userWantsRemoteDump());
-
-        if ($shouldDownloadDump) {
-            $importFilePath = $this->getRemoteDump();
-        } elseif ($optionFile) {
-            $localFilePath = $optionFile;
-        } elseif ($optionDump) {
-            $importFilePath = $this->getPathForDump($optionDump);
-        } elseif ($optionLatest) {
-            $importFilePath = $this->protector->getLatestDumpName();
-            $this->info(sprintf('Importing <comment>%s</comment>', $importFilePath));
-        } else {
-            $importFilePath = $this->chooseImportDump($optionConnection);
-        }
-
-        if (empty($localFilePath)) {
-            if (!$importFilePath) {
-                $this->error('Found no file to import.');
-
-                return self::FAILURE;
-            }
-
-            $localFilePath = $this->protector->createTempFilePath($importFilePath);
-        }
-
-        $this->importDump($localFilePath, $optionForce);
-
-        if (!$optionFile) {
-            unlink($localFilePath);
-        }
+        match (true) {
+            $this->option('remote') => $this->importDumpFromRemote(),
+            $hasFile => $this->importDumpFromFile(),
+            $this->option('latest') => $this->importLatestDump(),
+            default => $this->importInteractive(),
+        };
 
         return self::SUCCESS;
     }
 
     /**
      * Reads the remote dump file and deletes all old dumps if the flush option is set.
-     *
-     * @return string|null
      */
-    protected function getRemoteDump(): ?string
+    protected function importDumpFromRemote(): void
     {
         $disk = $this->protector->getDisk();
         $basePath = $this->protector->getBaseDirectory();
         $dumpEndpointUrl = $this->protector->getDumpEndpointUrl();
-        $absolutePath = $disk->path($basePath);
+        $absolutePathToBaseDirectory = $disk->path($basePath);
 
         $this->line(
-            sprintf('<<< Downloading dump from remote server to directory: <comment>%s</comment>', $absolutePath)
+            sprintf('<<< Downloading dump from remote server to directory: <comment>%s</comment>', $absolutePathToBaseDirectory)
         );
 
-        try {
-            $importFilePath = $this->protector->getRemoteDump();
-        } catch (Exception $exception) {
-            $this->error(sprintf('Error retrieving dump from remote server: %s', $exception->getMessage()));
-
-            return null;
-        }
-
-        if ($this->option('flush')) {
-            $this->protector->flush($importFilePath);
-            $this->warn(sprintf('Deleted all old files in %s', $absolutePath));
-        }
+        $relativeRemoteDumpFilePath = $this->protector->getRemoteDump();
 
         $this->line(sprintf('>>> Successfully retrieved remote dump from %s', $dumpEndpointUrl));
 
-        return $importFilePath;
+        if ($this->option('flush')) {
+            $this->protector->flush(excludeFile: $relativeRemoteDumpFilePath);
+            $this->warn(sprintf('Deleted all old files in %s', $absolutePathToBaseDirectory));
+        }
+
+        // We need to create a local temp file as the Protector disk might not be a local disk.
+        $this->importDumpFromTempFile($relativeRemoteDumpFilePath);
     }
 
     /**
-     * Checks if a dump with the specified name exists and return the file path.
+     * Imports a dump from a specific file path.
+     * The file path may be either absolute or relative to the dump directory.
      *
      * @throws FileNotFoundException
-     * @throws InvalidConfigurationException
      */
-    protected function getPathForDump(string $dumpName): string
+    protected function importDumpFromFile(): void
     {
-        $filePath = implode(DIRECTORY_SEPARATOR, [$this->protector->getBaseDirectory(), $dumpName]);
-        $disk = $this->protector->getDisk();
+        $isAbsoluteFilePath = $this->isAbsolutePath($this->option('file'));
+        $dumpFilePath = $isAbsoluteFilePath ? $this->option('file') : sprintf('%s%s%s', $this->protector->getBaseDirectory(), DIRECTORY_SEPARATOR, $this->option('file'));
 
-        if ($disk->exists($filePath)) {
-            return $filePath;
-        } else {
-            throw new FileNotFoundException($filePath);
+        switch ($isAbsoluteFilePath) {
+            case true:
+                $fileExists = file_exists($dumpFilePath);
+                $dumpFilePath = $this->option('file');
+                $importFn = fn() => $this->importDump($dumpFilePath, $this->option('force'));
+                break;
+            default:
+                $fileExists = $this->protector->getDisk()->exists($dumpFilePath);
+                $dumpFilePath = sprintf('%s%s%s', $this->protector->getBaseDirectory(), DIRECTORY_SEPARATOR, $this->option('file'));
+                // For relative paths, we need to create a local temp file as the Protector disk might not be a local disk.
+                $importFn = fn() => $this->importDumpFromTempFile($dumpFilePath);
+                break;
+        }
+
+        if (!$fileExists) {
+            throw new FileNotFoundException($dumpFilePath);
+        }
+
+        $importFn();
+    }
+
+    protected function importLatestDump(): void
+    {
+        $relativeImportFilePath = $this->protector->getLatestDumpName();
+
+        $this->info(sprintf('Importing <comment>%s</comment>', $relativeImportFilePath));
+
+        // We need to create a local temp file as the Protector disk might not be a local disk.
+        $this->importDumpFromTempFile($relativeImportFilePath);
+    }
+
+    protected function importInteractive(): void
+    {
+        if ($this->userWantsRemoteDump()) {
+            $this->importDumpFromRemote();
+
+            return;
+        }
+
+        $relativeImportFilePath = $this->chooseImportDump($this->option('connection'));
+
+        // We need to create a local temp file as the Protector disk might not be a local disk.
+        $this->importDumpFromTempFile($relativeImportFilePath);
+    }
+
+    /**
+     * Imports a dump file.
+     * If it is stored remotely, a local temporary file is created, imported, and deleted afterward.
+     */
+    protected function importDumpFromTempFile(string $dumpFilePath): void
+    {
+        if (!is_a($this->protector->getDisk()->getAdapter(), LocalFilesystemAdapter::class)) {
+            $absoluteLocalFilePath = $this->protector->createTempFilePath($dumpFilePath);
+        }
+
+        // We need an absolute file path going forward. The file path may already be absolute, only if called with the --file option and passed an absolute path.
+        if (!$this->isAbsolutePath($dumpFilePath)) {
+            $dumpFilePath = $this->protector->getDisk()->path($dumpFilePath);
+        }
+
+        try {
+            $this->importDump($absoluteLocalFilePath ?? $dumpFilePath, $this->option('force'));
+        } finally {
+            !empty($absoluteLocalFilePath) && unlink($absoluteLocalFilePath);
         }
     }
 
@@ -198,7 +215,7 @@ class ImportDump extends Command
     /**
      * Reads the metadata and returns a list of the available dumps.
      */
-    public function getMetadataForFiles(array $directoryFiles): Collection
+    protected function getMetadataForFiles(array $directoryFiles): Collection
     {
         $matchingFiles = collect();
 
@@ -253,7 +270,7 @@ class ImportDump extends Command
     /**
      * Imports the selected SQL dump.
      */
-    protected function importDump(string $importFilePath, ?bool $optionForce): void
+    protected function importDump(string $absoluteImportFilePath, ?bool $optionForce): void
     {
         if ($optionForce || $this->confirm(
                 sprintf(
@@ -261,28 +278,25 @@ class ImportDump extends Command
                     $this->protector->getDatabaseName()
                 )
             )) {
-            try {
-                $this->protector->importDump($importFilePath, Arr::except($this->options(), ['migrate']));
 
-                if ($this->option('migrate')) {
-                    $this->call('migrate');
-                }
+            $this->protector->importDump($absoluteImportFilePath, options: Arr::except($this->options(), ['migrate']));
 
-                $this->info('Import done!');
-            } catch (Exception $exception) {
-                $this->error($exception->getMessage());
+            if ($this->option('migrate')) {
+                $this->call('migrate');
             }
+
+            $this->info('Import done!');
         } else {
             $this->info('Import aborted');
         }
     }
 
     /**
-     * Returns a list of either all dumps, or those for the specified connection name.
+     * Returns a list of either all dumps or those for the specified connection name.
      *
      * @throws InvalidConnectionException|EmptyBaseDirectoryException
      */
-    public function getConnectionFiles(?string $connectionName = null): Collection
+    protected function getConnectionFiles(?string $connectionName = null): Collection
     {
         $sortedFiles = $this->getMetadataForFiles($this->protector->getDumpFiles())->sortByDesc('dateTime');
 
@@ -347,5 +361,10 @@ class ImportDump extends Command
         }
 
         return $this->choice('Import dump for which connection?', $connectionNames->toArray());
+    }
+
+    protected function isAbsolutePath(string $filePath): bool
+    {
+        return str_starts_with($filePath, DIRECTORY_SEPARATOR);
     }
 }

--- a/src/Commands/ImportDump.php
+++ b/src/Commands/ImportDump.php
@@ -99,10 +99,10 @@ class ImportDump extends Command
         $disk = $this->protector->getDisk();
         $basePath = $this->protector->getBaseDirectory();
         $dumpEndpointUrl = $this->protector->getDumpEndpointUrl();
-        $absolutePathToBaseDirectory = $disk->path($basePath);
+        $absoluteBasePath = $disk->path($basePath);
 
         $this->line(
-            sprintf('<<< Downloading dump from remote server to directory: <comment>%s</comment>', $absolutePathToBaseDirectory)
+            sprintf('<<< Downloading dump from remote server to directory: <comment>%s</comment>', $absoluteBasePath)
         );
 
         $relativeRemoteDumpFilePath = $this->protector->getRemoteDump();
@@ -111,7 +111,7 @@ class ImportDump extends Command
 
         if ($this->option('flush')) {
             $this->protector->flush(excludeFile: $relativeRemoteDumpFilePath);
-            $this->warn(sprintf('Deleted all old files in %s', $absolutePathToBaseDirectory));
+            $this->warn(sprintf('Deleted all old files in %s', $absoluteBasePath));
         }
 
         return $relativeRemoteDumpFilePath;

--- a/src/Commands/ImportDump.php
+++ b/src/Commands/ImportDump.php
@@ -30,7 +30,7 @@ class ImportDump extends Command
                 {--f|file= : Either an absolute path to a file, or a filename relative to the protector dump directory. }
                 {--c|connection= : The configured database-connection in Laravel\'s config/database.php. }
                 {--allow-production : Enable importing SQL dumps on a production system. }
-                {--force : Forces the import of the given file or remote download. Requires the file, remote or latest option. }
+                {--force : Skips confirmation prompts. Requires the file, remote or latest option. }
                 {--i|ignore-connection-filter : Ignores filter of dumps to defined connections. }
                 {--r|remote : Pull a fresh dump from the remote server as configured in the .env file. Will be used as fallback when combined with other options. }
                 {--flush : Delete all existing dumps in the dump folder when using a remote dump. }

--- a/src/Commands/ImportDump.php
+++ b/src/Commands/ImportDump.php
@@ -70,7 +70,9 @@ class ImportDump extends Command
         $hasFile = !empty(trim($this->option('file')));
 
         if ($this->option('force') && !($this->option('remote') || $hasFile || $this->option('latest'))) {
-            $this->fail('Nothing to import. You need to specify either --remote, --file, or --latest.');
+            $this->error('Nothing to import. You need to specify either --remote, --file, or --latest.');
+
+            return self::FAILURE;
         }
 
         match (true) {

--- a/src/Protector.php
+++ b/src/Protector.php
@@ -6,6 +6,7 @@ use Cybex\Protector\Classes\Metadata\MetadataHandler;
 use Cybex\Protector\Classes\SchemaState\MySql\MySqlSchemaStateProxy;
 use Cybex\Protector\Classes\SchemaState\Postgres\PostgresSchemaStateProxy;
 use Cybex\Protector\Contracts\Crypter;
+use Cybex\Protector\Exceptions\EmptyBaseDirectoryException;
 use Cybex\Protector\Exceptions\FailedCreatingDestinationPathException;
 use Cybex\Protector\Exceptions\FailedDumpGenerationException;
 use Cybex\Protector\Exceptions\FailedImportException;
@@ -490,7 +491,7 @@ class Protector
     /**
      * Returns the name of the most recent dump.
      *
-     * @throws FileNotFoundException
+     * @throws EmptyBaseDirectoryException
      */
     public function getLatestDumpName(): string
     {
@@ -499,7 +500,7 @@ class Protector
         $files = $disk->files($baseDirectory);
 
         if (empty($files)) {
-            throw new FileNotFoundException($disk->path($baseDirectory));
+            throw new EmptyBaseDirectoryException();
         }
 
         usort($files, function ($a, $b) use ($disk) {

--- a/tests/Feature/ImportDumpCommandTest.php
+++ b/tests/Feature/ImportDumpCommandTest.php
@@ -148,7 +148,6 @@ class ImportDumpCommandTest extends TestCase
         $this->artisan(sprintf('protector:import --file=%s --force', $fileName))->assertFailed();
     }
 
-
     /**
      * @test
      */

--- a/tests/Feature/ImportDumpCommandTest.php
+++ b/tests/Feature/ImportDumpCommandTest.php
@@ -145,7 +145,7 @@ class ImportDumpCommandTest extends TestCase
 
         $this->expectExceptionObject(new FileNotFoundException(path: sprintf('%s%s%s', static::$baseDirectory, DIRECTORY_SEPARATOR, $fileName)));
 
-        $this->artisan(sprintf('protector:import --file=%s --ignore-connection-filter --force', $fileName))->assertFailed();
+        $this->artisan(sprintf('protector:import --file=%s --force', $fileName))->assertFailed();
     }
 
 

--- a/tests/Feature/ImportDumpCommandTest.php
+++ b/tests/Feature/ImportDumpCommandTest.php
@@ -3,6 +3,7 @@
 namespace Cybex\Protector\Tests\Feature;
 
 use Cybex\Protector\Exceptions\EmptyBaseDirectoryException;
+use Cybex\Protector\Exceptions\FailedRemoteDatabaseFetchingException;
 use Cybex\Protector\Exceptions\FileNotFoundException;
 use Cybex\Protector\Exceptions\InvalidConnectionException;
 use Cybex\Protector\Exceptions\InvalidEnvironmentException;
@@ -10,6 +11,7 @@ use Cybex\Protector\Tests\TestCase;
 use Illuminate\Contracts\Filesystem\Filesystem;
 use Illuminate\Support\Facades\Config;
 use Illuminate\Support\Facades\Http;
+use League\Flysystem\Local\LocalFilesystemAdapter;
 
 class ImportDumpCommandTest extends TestCase
 {
@@ -19,6 +21,8 @@ class ImportDumpCommandTest extends TestCase
     protected string $shouldDownloadDump;
     protected string $shouldImportDump;
     protected static string $baseDirectory = 'dumps';
+
+    protected const DUMP_SOURCE_CHOICE = ['Download remote dump', 'Import existing local dump'];
 
     protected function setUp(): void
     {
@@ -66,7 +70,7 @@ class ImportDumpCommandTest extends TestCase
         $this->expectException(InvalidConnectionException::class);
 
         $this->artisan('protector:import --connection=sqlite')
-            ->expectsChoice($this->shouldDownloadDump, 2, ['Download remote dump', 'Import existing local dump']);
+            ->expectsChoice($this->shouldDownloadDump, 2, static::DUMP_SOURCE_CHOICE);
     }
 
     /**
@@ -127,11 +131,9 @@ class ImportDumpCommandTest extends TestCase
      */
     public function failGetRemoteOnDumpWithNoResponse()
     {
-        $this->artisan('protector:import --remote')
-            ->expectsOutput(
-                "Error retrieving dump from remote server: Could not fetch database from remote server: The scheme '' is not supported."
-            )
-            ->assertFailed();
+        $this->expectException(FailedRemoteDatabaseFetchingException::class);
+
+        $this->artisan('protector:import --remote')->assertFailed();
     }
 
     /**
@@ -141,19 +143,11 @@ class ImportDumpCommandTest extends TestCase
     {
         $fileName = 'thisDumpDoesNotExist.sql';
 
-        $this->artisan(sprintf('protector:import --file=%s --ignore-connection-filter --force', $fileName))
-            ->expectsOutput(sprintf('The file "%s" was not found.', $fileName));
+        $this->expectExceptionObject(new FileNotFoundException(path: sprintf('%s%s%s', static::$baseDirectory, DIRECTORY_SEPARATOR, $fileName)));
+
+        $this->artisan(sprintf('protector:import --file=%s --ignore-connection-filter --force', $fileName))->assertFailed();
     }
 
-    /**
-     * @test
-     */
-    public function failOptionDumpOnNonExistingDump()
-    {
-        $this->expectException(FileNotFoundException::class);
-
-        $this->artisan('protector:import --dump=thisFileDoesNotExist');
-    }
 
     /**
      * @test
@@ -161,6 +155,7 @@ class ImportDumpCommandTest extends TestCase
     public function canImportDumpOnOptionLatest()
     {
         $this->artisan('protector:import --latest')->expectsConfirmation($this->shouldImportDump);
+
         $this->assertEquals(
             sprintf('%s%sdump.sql', $this->protector->getBaseDirectory(), DIRECTORY_SEPARATOR),
             $this->protector->getLatestDumpName()
@@ -177,7 +172,7 @@ class ImportDumpCommandTest extends TestCase
         $this->expectException(EmptyBaseDirectoryException::class);
 
         $this->artisan('protector:import')
-            ->expectsChoice($this->shouldDownloadDump, 2, ['Download remote Dump']);
+            ->expectsChoice($this->shouldDownloadDump, 2, static::DUMP_SOURCE_CHOICE);
     }
 
     /**
@@ -190,8 +185,16 @@ class ImportDumpCommandTest extends TestCase
         $this->assertCount(1, $this->protector->getDumpFiles());
 
         $this->artisan('protector:import')
-            ->expectsChoice($this->shouldDownloadDump, 2, ['Download remote dump', 'Import existing local dump'])
+            ->expectsChoice($this->shouldDownloadDump, 2, static::DUMP_SOURCE_CHOICE)
             ->expectsOutput('Using file "' . static::$baseDirectory . '/dump.sql" because there are no other dumps.')
             ->expectsConfirmation($this->shouldImportDump);
+    }
+
+    /**
+     * @test
+     */
+    public function ensureFilesystemAdapterCanBeRetrieved()
+    {
+        $this->assertTrue(is_a($this->protector->getDisk()->getAdapter(), LocalFilesystemAdapter::class));
     }
 }

--- a/tests/Feature/ImportDumpTest.php
+++ b/tests/Feature/ImportDumpTest.php
@@ -3,6 +3,7 @@
 namespace Cybex\Protector\Tests\Feature;
 
 use Carbon\Carbon;
+use Cybex\Protector\Exceptions\EmptyBaseDirectoryException;
 use Cybex\Protector\Exceptions\FailedImportException;
 use Cybex\Protector\Exceptions\FailedWipeException;
 use Cybex\Protector\Exceptions\FileNotFoundException;
@@ -203,7 +204,7 @@ class ImportDumpTest extends TestCase
     public function throwsExceptionIfNoFileExists()
     {
         $this->clearDumpDirectory();
-        $this->expectException(FileNotFoundException::class);
+        $this->expectException(EmptyBaseDirectoryException::class);
         $this->protector->getLatestDumpName();
     }
 


### PR DESCRIPTION
Closes #34 

This PR will
- refactor the protector:import command
- remove the --dump parameter (replaced with --file)
- use a more accurate exception for `getLatestDumpName`
- fix an issue caused by the Command::fail() function not being available in older Laravel versions